### PR TITLE
Keep map actions aligned on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,12 +765,24 @@
             }
 
             .map-buttons {
-                flex-direction: column;
-                align-items: flex-start;
+                flex-direction: row;
+                align-items: center;
+                gap: 12px;
             }
 
             .map-links {
-                margin-left: 0;
+                margin-left: auto;
+                gap: 10px;
+            }
+
+            .map-links a {
+                width: 36px;
+                height: 36px;
+            }
+
+            .map-logo {
+                width: 20px;
+                height: 20px;
             }
 
             .modal-nav {


### PR DESCRIPTION
## Summary
- keep the menu and map actions in a single row on phones
- reduce spacing and icon sizes so the buttons fit within narrow cards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc5aa1638832481c012c4d39f8155