### PR TITLE
Improve NAVER Map restroom shortcut behavior

### DIFF
--- a/app.js
+++ b/app.js
@@ -249,6 +249,13 @@ createApp({
             const { app, web } = this.buildNaverMapUrls(restaurant);
             this.openNaverMap(app, web);
         },
+        handleOpenRestroomSearch() {
+            const keyword = '화장실';
+            const encodedKeyword = encodeURIComponent(keyword);
+            const appUrl = `nmap://search?query=${encodedKeyword}&appname=com.max.everland`;
+            const webUrl = `https://map.naver.com/p/search/${encodedKeyword}`;
+            this.openNaverMap(appUrl, webUrl);
+        },
         openNaverMap(url, webUrl) {
             const start = new Date().getTime();
             window.location.href = url;

--- a/index.html
+++ b/index.html
@@ -35,6 +35,36 @@
             margin: 0;
         }
 
+        .naver-map-link {
+            position: fixed;
+            top: 16px;
+            right: 20px;
+            width: 52px;
+            height: 52px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.9);
+            box-shadow: 0 12px 24px rgba(31, 42, 68, 0.18);
+            color: var(--accent-color);
+            font-size: 28px;
+            text-decoration: none;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+            z-index: 400;
+            border: none;
+            cursor: pointer;
+            padding: 0;
+        }
+
+        .naver-map-link:hover,
+        .naver-map-link:focus-visible {
+            transform: translateY(-2px);
+            box-shadow: 0 16px 32px rgba(31, 42, 68, 0.24);
+            background: #fff;
+            outline: none;
+        }
+
         #app {
             min-height: 100vh;
         }
@@ -815,6 +845,14 @@
 </head>
 <body>
     <div id="app">
+        <button
+            type="button"
+            class="naver-map-link"
+            @click="handleOpenRestroomSearch"
+            aria-label="在 NAVER MAP 搜尋 화장실"
+        >
+            <span aria-hidden="true">🚻</span>
+        </button>
         <div class="page-container">
             <header>
                 <h1 class="page-title">Everland 餐廳探索</h1>


### PR DESCRIPTION
## Summary
- add a floating toilet icon button at the top of the page
- open the NAVER Map 화장실 search via deep-link behavior to prompt opening the app without navigating away, with a browser fallback

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0a1f373148324aadc0b6de893fe85